### PR TITLE
fix: throw InvalidTokenError in verifyAccessToken

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { OryProvider, OryOptions } from './index.js';
 import { OAuthClientInformationFull, OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js';
-import { ServerError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import { ServerError, InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { Response } from 'express';
 
 // Mock global fetch
@@ -293,7 +293,7 @@ describe('OryProvider', () => {
       });
 
       await expect(provider.verifyAccessToken('inactive-token')).rejects.toThrow(
-        'Token is not active'
+        new InvalidTokenError('Token is not active')
       );
       expect(mockFetch.mock.calls.length).toBe(1);
     });
@@ -318,7 +318,7 @@ describe('OryProvider', () => {
         });
 
       await expect(provider.verifyAccessToken('test-token')).rejects.toThrow(
-        'Token client ID mismatch'
+        new InvalidTokenError('Token client ID mismatch')
       );
       expect(mockFetch.mock.calls.length).toBe(2);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright © 2025 Ory Corp
 
 import { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
-import { ServerError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import { ServerError, InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import {
   AuthorizationParams,
   OAuthServerProvider,
@@ -380,14 +380,14 @@ export class OryProvider implements OAuthServerProvider {
       const introspection = await this.introspectToken(token);
 
       if (!introspection.active) {
-        throw new Error('Token is not active');
+        throw new InvalidTokenError('Token is not active');
       }
 
       const clients = await this.listOAuth2Clients();
       const client = clients[introspection.client_id];
 
       if (!client) {
-        throw new Error('Token client ID mismatch');
+        throw new InvalidTokenError('Token client ID mismatch');
       }
 
       return {


### PR DESCRIPTION
## Summary

This pull request updates the error handling logic within the `verifyAccessToken` method in `OryProvider`.

Previously, generic `Error` instances were thrown when token validation failed due to inactive tokens or mismatched client IDs. This change replaces them with semantically accurate custom error types (`InvalidTokenError`) imported from the `@modelcontextexprotocol/sdk/server/auth/errors.js` module.

The change ensures compatibility with the MCP Client, which specifically expects `InvalidTokenError` to trigger a re-login flow and obtain a new access token. Without this, token renewal does not happen automatically.

Reference: [MCP SDK bearerAuth implementation](https://github.com/modelcontextprotocol/typescript-sdk/blob/0506addf35f422650658c5e665ea184e3115a184/src/server/auth/middleware/bearerAuth.ts#L74-L93)

No breaking changes introduced.

## Related Issue or Design Document

This is a fix for a previously undocumented bug where invalid or inactive tokens resulted in non-specific `Error` exceptions, making error classification harder in consuming layers.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability.
- [x] I have added tests that prove my fix is effective or that my feature works. *(Assumed; mark if applicable)*
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

This change ensures interoperability between Ory token validation and MCP client-side error handling logic.